### PR TITLE
Each path segment of the Canonical URI must be encoded twice.

### DIFF
--- a/requests_auth_aws_sigv4/__init__.py
+++ b/requests_auth_aws_sigv4/__init__.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import logging
 import os
+import urllib.parse
 from datetime import datetime
 
 from requests import __version__ as requests_version
@@ -103,7 +104,10 @@ class AWSSigV4(AuthBase):
         url_parts = urlparse(r.url)
         log.debug("Request URL: %s", url_parts)
         host = url_parts.hostname
-        uri = url_parts.path
+        uri_segments = []
+        for segment in url_parts.path.split('/'):
+            uri_segments.append(urllib.parse.quote(segment, safe=''))
+        uri = '/'.join(uri_segments)
         if len(url_parts.query) > 0:
             qs = dict(map(lambda i: i.split('='), url_parts.query.split('&')))
         else:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import pytest
 from requests.models import Request
 from mockito import when, spy2, unstub
@@ -87,6 +89,29 @@ def test_call_simple(frozentime):
         f"AWS4-HMAC-SHA256 Credential=key_id/{frozentime:%Y%m%d}/test-region-1/test/aws4_request",
         f"SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
         f"Signature=817adf89563cdf0728f4e684c9ac9ead2cca25c4610e9bb3ddfebe8665ea72f2"
+    ])
+    assert result.headers['Host'] == "testhost"
+    assert result.headers['Content-Type'] == "application/x-www-form-urlencoded; charset=utf-8"
+    assert result.headers['User-Agent'] == 'python-requests/{} auth-aws-sigv4/{}'.format(
+        requests_auth_aws_sigv4.requests_version, requests_auth_aws_sigv4.__version__)
+    assert result.headers['X-AMZ-Date'] == frozentime.strftime('%Y%m%dT%H%M%SZ')
+    assert result.headers['x-amz-security-token'] == "token"
+    assert result.headers['x-amz-content-sha256'] == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def test_uri_double_encoded_segment(frozentime):
+    aws_auth = requests_auth_aws_sigv4.AWSSigV4('test', region='test-region-1',
+                                                aws_access_key_id="key_id",
+                                                aws_secret_access_key="secret_key",
+                                                aws_session_token="token")
+    segment = urllib.parse.quote('123 / abc', safe='')
+    req = Request('GET', f'https://testhost/action/{segment}?param=value')
+    result = aws_auth(req.prepare())
+    assert 'Authorization' in result.headers
+    assert result.headers['Authorization'] == ", ".join([
+        f"AWS4-HMAC-SHA256 Credential=key_id/{frozentime:%Y%m%d}/test-region-1/test/aws4_request",
+        f"SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+        f"Signature=89a91408e96df9231d23bc51aa31916f1f72db68d6e96ba633c6652ba86fe2cd"
     ])
     assert result.headers['Host'] == "testhost"
     assert result.headers['Content-Type'] == "application/x-www-form-urlencoded; charset=utf-8"


### PR DESCRIPTION
https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

> Add the canonical URI parameter, followed by a newline character. The canonical URI is the URI-encoded version of the absolute path component of the URI, which is everything in the URI from the HTTP host to the question mark character ("?") that begins the query string parameters (if any).
> 
> Normalize URI paths according to [RFC 3986](https://tools.ietf.org/html/rfc3986). Remove redundant and relative path components. Each path segment must be URI-encoded twice ([except for Amazon S3 which only gets URI-encoded once](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)).
> 
> Example Canonical URI with encoding
> 
> /documents%2520and%2520settings/

The use case for this issue is using the Amazon Seller API:

[GET /products/pricing/v0/listings/{SellerSKU}/offers](https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#get-productspricingv0listingssellerskuoffers)

The SellerSKU must be double encoded in the canonical URI, which is currently not happening.