### PR TITLE
Compute hash when GET has body

### DIFF
--- a/requests_auth_aws_sigv4/__init__.py
+++ b/requests_auth_aws_sigv4/__init__.py
@@ -128,7 +128,7 @@ class AWSSigV4(AuthBase):
         canonical_querystring = "&".join(map(lambda p: "=".join(p), sorted(qs.items())))
 
         # Create payload hash (hash of the request body content).
-        if r.method == 'GET':
+        if r.method == 'GET' and not r.body:
             payload_hash = hashlib.sha256(''.encode('utf-8')).hexdigest()
         else:
             if r.body:


### PR DESCRIPTION
Some services, e.g. OpenSearch, expect a body to set search query parameters when making a GET request. This PR changes the payload hashing logic to ensure GET body is hashed.