### PR TITLE
Support unsigned payload

### DIFF
--- a/requests_auth_aws_sigv4/__main__.py
+++ b/requests_auth_aws_sigv4/__main__.py
@@ -47,6 +47,8 @@ def run(run_args=None):
                      help="Specify request command to use")
     cli.add_argument('-d', '--data', action='append',
                      help="HTTP POST data; changes request command to 'POST'")
+    cli.add_argument('-u', '--unsigned-payload', action='store_true',
+                    help="Do not sign the payload. Payload is signed by default.")
 
     # Additional, non-cURL options
     cli.add_argument('--debug', action='store_true', help="Enable debug output")
@@ -83,7 +85,8 @@ def run(run_args=None):
     # Do Request
     try:
         r = requests.request(args.request, args.url, headers=headers, data=post_data,
-                             auth=AWSSigV4(args.service, region=args.region))
+                             auth=AWSSigV4(args.service, region=args.region,
+                                           payload_signing_enabled=not args.unsigned_payload))
     except KeyError as e:
         print("Error:", ", ".join(e.args))
         sys.exit(1)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -99,6 +99,24 @@ def test_call_simple(frozentime):
     assert result.headers['x-amz-content-sha256'] == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 
+def test_call_no_payload_signing(frozentime):
+    aws_auth = requests_auth_aws_sigv4.AWSSigV4('test', region='test-region-1',
+                                                aws_access_key_id="key_id",
+                                                aws_secret_access_key="secret_key",
+                                                aws_session_token="token",
+                                                payload_signing_enabled=False,
+                                                )
+    req = Request('GET', "https://testhost/action?param=value")
+    result = aws_auth(req.prepare())
+    assert 'Authorization' in result.headers
+    assert result.headers['Authorization'] == ", ".join([
+        f"AWS4-HMAC-SHA256 Credential=key_id/{frozentime:%Y%m%d}/test-region-1/test/aws4_request",
+        f"SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+        f"Signature=a5e20a7d27d57597b3776e04f087343407397fe2418e40cf85ffab051dd2cf1d"
+    ])
+    assert result.headers['x-amz-content-sha256'] == "UNSIGNED-PAYLOAD"
+
+
 def test_uri_double_encoded_segment(frozentime):
     aws_auth = requests_auth_aws_sigv4.AWSSigV4('test', region='test-region-1',
                                                 aws_access_key_id="key_id",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,7 +47,7 @@ def mock_auth():
         }, spec=requests.Response)
         mock_AWSSigV4 = mock(main.AWSSigV4)
         when(mock_AWSSigV4).__call__(mock_request).thenReturn(mock_request)
-        when(main).AWSSigV4("service", region="tt-region-1").thenReturn(mock_AWSSigV4)
+        when(main).AWSSigV4("service", region="tt-region-1", payload_signing_enabled=True).thenReturn(mock_AWSSigV4)
         when(requests).request(...).thenReturn(mock_response)
         return mock_response
     yield _make


### PR DESCRIPTION
It is sometimes useful to not sign the payload
(e.g. for performance reasons) - let this be an option.
`payload_signing_enabled` parameter is the same as in `botocore.config.Config`.

The change is backwards compatible.